### PR TITLE
Update Makefile.rules for clang SA

### DIFF
--- a/SCRAM/GMake/Makefile.rules
+++ b/SCRAM/GMake/Makefile.rules
@@ -513,7 +513,7 @@ define analyze_cxx_common
   $(call run_analyze_command,$1,$2,$3,$4,$(CXX) -c -### $(3) $(CXXOPTIMISEDFLAGS) $(CXXSHAREDOBJECTFLAGS))
 endef
 define analyze_c_common
-  $(call run_analyze_command,$1,$2,$3,$4,$(CC) -### $(3) $(COPTIMISEDFLAGS) $(CSHAREDOBJECTFLAGS))
+  $(call run_analyze_command,$1,$2,$3,$4,$(CC) -c -### $(3) $(COPTIMISEDFLAGS) $(CSHAREDOBJECTFLAGS))
 endef
 
 ##############################################################################


### PR DESCRIPTION
Change flags on checker rule for running clang static analyzer to greatly speed up the job
