### PR TITLE
CMSSW_BuildFile: add ASAN CXXFLAGS

### DIFF
--- a/CMSSW_BuildFile.xml
+++ b/CMSSW_BuildFile.xml
@@ -50,3 +50,6 @@
 <architecture name="_mic_">
   <flags CPPDEFINES="thread_local="/>
 </architecture>
+<release name=".*_ASAN_.*">
+  <flags CXXFLAGS="-g -fno-omit-frame-pointer -fsanitize=address"/>
+</release>


### PR DESCRIPTION
The following adds CXXFLAGS for ASAN CMSSW IBs.
ASAN == Address Sanitizer

Signed-off-by: David Abdurachmanov davidlt@cern.ch
