### PR TITLE
Add -k to skip clang compiler errors and add exit 0

### DIFF
--- a/dxr.config
+++ b/dxr.config
@@ -8,4 +8,4 @@ wwwroot         = /dxr
 [CMSSW]
 source_folder   = @LOCALTOP@/src
 object_folder   = @LOCALTOP@/src
-build_command   = scram b -f -v -k -j $jobs compile COMPILER=llvm-analyzer SCRAM_IGNORE_MISSING_COMPILERS=yes; exit 0
+build_command   = SCRAM_DXR_RUN=yes scram b -f -v -k -j $jobs compile COMPILER=llvm-analyzer SCRAM_IGNORE_MISSING_COMPILERS=yes; exit 0


### PR DESCRIPTION
otherwise dxr.build.py will exit before creating the index database.
