### PR TITLE
Update rules for linking CUDA device code

### DIFF
--- a/SCRAM/GMake/Makefile.rules
+++ b/SCRAM/GMake/Makefile.rules
@@ -623,8 +623,8 @@ endef
 define link_cuda_objs
   @$(startlog_$(1)) [ -d $(@D) ] ||  $(CMD_mkdir) -p $(@D) &&\
   $(CMD_echo) ">> Cuda Device Link $@ " &&\
-  $(VERB_ECHO) $(SCRAM_PREFIX_COMPILER_COMMAND) "$(NVCC) -dlink $(call AdjustFlags,$1,,CUDA_FLAGS CUDA_LDFLAGS) $? -o $@" &&\
-              ($(SCRAM_PREFIX_COMPILER_COMMAND) $(NVCC) -dlink $(call AdjustFlags,$1,,CUDA_FLAGS CUDA_LDFLAGS) $? -o $@) $(endlog_$(1))
+  $(VERB_ECHO) $(SCRAM_PREFIX_COMPILER_COMMAND) "$(NVCC) -dlink $(call AdjustFlags,$1,,CUDA_FLAGS CUDA_LDFLAGS) -lcudadevrt $? -o $@" &&\
+              ($(SCRAM_PREFIX_COMPILER_COMMAND) $(NVCC) -dlink $(call AdjustFlags,$1,,CUDA_FLAGS CUDA_LDFLAGS) -lcudadevrt $? -o $@) $(endlog_$(1))
 endef
 ##############################################################################
 # Dictionary compilation


### PR DESCRIPTION
Hardcode `-lcudadevrt` as the last library to be linked during the `nvcc -dlink` step.