### PR TITLE
Update rules for linking CUDA device code

### DIFF
--- a/SCRAM/GMake/Makefile.rules
+++ b/SCRAM/GMake/Makefile.rules
@@ -624,8 +624,8 @@ endef
 define link_cuda_objs
   @$(startlog_$(1)) [ -d $(@D) ] ||  $(CMD_mkdir) -p $(@D) &&\
   $(CMD_echo) ">> Cuda Device Link $@ " &&\
-  $(VERB_ECHO) $(SCRAM_PREFIX_COMPILER_COMMAND) "$(NVCC) -dlink $(call AdjustFlags,$1,,CUDA_FLAGS CUDA_LDFLAGS) -lcudadevrt $? -o $@" &&\
-              ($(SCRAM_PREFIX_COMPILER_COMMAND) $(NVCC) -dlink $(call AdjustFlags,$1,,CUDA_FLAGS CUDA_LDFLAGS) -lcudadevrt $? -o $@) $(endlog_$(1))
+  $(VERB_ECHO) $(SCRAM_PREFIX_COMPILER_COMMAND) "$(NVCC) -dlink -shared $(call AdjustFlags,$1,,CUDA_FLAGS CUDA_LDFLAGS) -lcudadevrt $? -o $@" &&\
+              ($(SCRAM_PREFIX_COMPILER_COMMAND) $(NVCC) -dlink -shared $(call AdjustFlags,$1,,CUDA_FLAGS CUDA_LDFLAGS) -lcudadevrt $? -o $@) $(endlog_$(1))
 endef
 ##############################################################################
 # Dictionary compilation


### PR DESCRIPTION
Add the `-shared` flag to the `nvcc -dlink` step, to produce relocatable object files.