### PR TITLE
Add alloc_dealloc_mismatch=0 to ASAN_OPTIONS

### DIFF
--- a/CMSSW_Self.xml
+++ b/CMSSW_Self.xml
@@ -42,6 +42,6 @@
  <runtime name="LANG"                  value="C"/>
  <runtime name="TEST_SRTOPT_PATH"      value="$LOCALTOP/test/$SCRAM_ARCH"            type="path"/>
  <release name="_ASAN_">
-  <runtime name="ASAN_OPTIONS"         value="detect_leaks=0"/>
+  <runtime name="ASAN_OPTIONS"         value="detect_leaks=0:alloc_dealloc_mismatch=0"/>
  </release>
 </tool>


### PR DESCRIPTION
This is until we can figure out reports, e.g. in 135.12 step2:

    =================================================================
    ==31969==ERROR: AddressSanitizer: alloc-dealloc-mismatch (malloc vs operator delete) on 0x6100003a9940
        #0 0x7f6fc4d96548 in operator delete(void*, unsigned long) ../../../../libsanitizer/asan/asan_new_delete.cc:140
        #1 0x7f6fc36c4d23 in ROOT::Fit::FitResult::~FitResult() (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/external/slc6_amd64_gcc700/lib/libMathCore.so+0xb9d23)
        #2 0x7f6fbb0b075a in std::_Sp_counted_ptr<TFitResult*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/external/slc6_amd64_gcc700/lib/libHist.so+0x17675a)
        #3 0x42192c in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() (/cvmfs/cms-ib.cern.ch/nweek-02497/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/bin/slc6_amd64_gcc700/cmsRun+0x42192c)
        #4 0x7f6fc36d3217 in ROOT::Fit::Fitter::~Fitter() (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/external/slc6_amd64_gcc700/lib/libMathCore.so+0xc8217)
        #5 0x7f6fbb0ac071 in std::_Sp_counted_ptr<ROOT::Fit::Fitter*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/external/slc6_amd64_gcc700/lib/libHist.so+0x172071)
        #6 0x7f6fbb0c2fe9 in TBackCompFitter::~TBackCompFitter() (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/external/slc6_amd64_gcc700/lib/libHist.so+0x188fe9)
        #7 0x7f6fbb0c3018 in TBackCompFitter::~TBackCompFitter() (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/external/slc6_amd64_gcc700/lib/libHist.so+0x189018)
        #8 0x7f6fbb0b5674 in TFitResultPtr HFit::Fit<TH1>(TH1*, TF1*, Foption_t&, ROOT::Math::MinimizerOptions const&, char const*, ROOT::Fit::DataRange&) (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/external/slc6_amd64_gcc700/lib/libHist.so+0x17b674)
        #9 0x7f6fbb0aba54 in ROOT::Fit::FitObject(TH1*, TF1*, Foption_t&, ROOT::Math::MinimizerOptions const&, char const*, ROOT::Fit::DataRange&) (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/external/slc6_amd64_gcc700/lib/libHist.so+0x171a54)
        #10 0x7f6fbb157e82 in TH1::Fit(TF1*, char const*, char const*, double, double) (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/external/slc6_amd64_gcc700/lib/libHist.so+0x21de82)
        #11 0x7f6fbb17e0d5 in TH2::DoFitSlices(bool, TF1*, int, int, int, char const*, TObjArray*) (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/external/slc6_amd64_gcc700/lib/libHist.so+0x2440d5)
        #12 0x7f6fbb1780af in TH2::FitSlicesY(TF1*, int, int, int, char const*, TObjArray*) (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/external/slc6_amd64_gcc700/lib/libHist.so+0x23e0af)
        #13 0x7f6f9c593dd0 in FitSlicesYTool::FitSlicesYTool(MonitorElement*) (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/lib/slc6_amd64_gcc700/libDQMServicesClientConfig.so+0xcdd0)
        #14 0x7f6f9c6260d4 in DQMGenericClient::computeResolution(DQMStore::IBooker&, DQMStore::IGetter&, std::string const&, std::string const&, std::string const&, std::string const&) (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/lib/slc6_amd64_gcc700/pluginDQMServicesClientConfigPlugins.so+0x370d4)
        #15 0x7f6f9c6292a7 in DQMGenericClient::dqmEndJob(DQMStore::IBooker&, DQMStore::IGetter&) (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/lib/slc6_amd64_gcc700/pluginDQMServicesClientConfigPlugins.so+0x3a2a7)
        #16 0x7f6fb4cccf0c in DQMEDHarvester::endJob() (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/lib/slc6_amd64_gcc700/libDQMServicesCore.so+0x91f0c)
        #17 0x7f6fc4a88986 in edm::Worker::endJob() (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/lib/slc6_amd64_gcc700/libFWCoreFramework.so+0x5c0986)
        #18 0x7f6fc493f66b in edm::WorkerManager::endJob(edm::ExceptionCollector&) (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/lib/slc6_amd64_gcc700/libFWCoreFramework.so+0x47766b)
        #19 0x7f6fc46447f3 in edm::Schedule::endJob(edm::ExceptionCollector&) (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/lib/slc6_amd64_gcc700/libFWCoreFramework.so+0x17c7f3)
        #20 0x7f6fc49b0201 in edm::EventProcessor::endJob() (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/lib/slc6_amd64_gcc700/libFWCoreFramework.so+0x4e8201)
        #21 0x413020 in main::{lambda()#1}::operator()() const (/cvmfs/cms-ib.cern.ch/nweek-02497/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/bin/slc6_amd64_gcc700/cmsRun+0x413020)
        #22 0x40d322 in main (/cvmfs/cms-ib.cern.ch/nweek-02497/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/bin/slc6_amd64_gcc700/cmsRun+0x40d322)
        #23 0x3f8ee1ed1c in __libc_start_main (/lib64/libc.so.6+0x3f8ee1ed1c)
        #24 0x40da88  (/cvmfs/cms-ib.cern.ch/nweek-02497/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/bin/slc6_amd64_gcc700/cmsRun+0x40da88)

    0x6100003a9940 is located 0 bytes inside of 184-byte region [0x6100003a9940,0x6100003a99f8)
    allocated by thread T0 here:
        #0 0x7f6fc4d93aa0 in __interceptor_malloc ../../../../libsanitizer/asan/asan_malloc_linux.cc:62
        #1 0x7f6fc24d1237 in operator new(unsigned long) ../../../../libstdc++-v3/libsupc++/new_op.cc:50
        #2 0x7f6fb1d6477e in TClingCallFunc::exec(void*, void*) (/cvmfs/cms-ib.cern.ch/week1/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_0_ASAN_X_2017-11-09-2300/external/slc6_amd64_gcc700/lib/libCling.so+0x3b177e)
        #3 0x604001968067  (<unknown module>)

    SUMMARY: AddressSanitizer: alloc-dealloc-mismatch ../../../../libsanitizer/asan/asan_new_delete.cc:140 in operator delete(void*, unsigned long)
    ==31969==HINT: if you don't care about these errors you may set ASAN_OPTIONS=alloc_dealloc_mismatch=0
    ==31969==ABORTING

Signed-off-by: David Abdurachmanov <david.abdurachmanov@gmail.com>