### PR TITLE
Putting this back where it was for the config tag for CMSSW_10_0_0 allows dxr to run properly.

### DIFF
--- a/SCRAM/GMake/Makefile.rules
+++ b/SCRAM/GMake/Makefile.rules
@@ -1,4 +1,5 @@
 -include $(TOOLS_MKDIR).mk
+$(foreach f,LLVM_ANALYZER,$(eval $f:=$(self_EX_FLAGS_$f)))
 LIB_TYPES:=$(sort $(ALL_LIB_TYPES))
 OVERRIDABLE_FLAGS:=$(strip $(sort $(TOOLS_OVERRIDABLE_FLAGS) $(foreach x,$(patsubst %_LIB,%,$(LIB_TYPES)),$x_LDFLAGS)))
 ALL_COMPILER_FLAGS:=$(sort $(ALL_COMPILER_FLAGS) $(OVERRIDABLE_FLAGS))


### PR DESCRIPTION
 It is a duplicated lower in the file but apparently it needs to be set before any modifications are made.