### PR TITLE
Reorder CUDA device libraries

### DIFF
--- a/CMSSW_BuildFile.xml
+++ b/CMSSW_BuildFile.xml
@@ -5,7 +5,7 @@
 <productstore name="objs"      type="arch" swap="true"/>
 <productstore name="biglib"    type="arch" swap="true"/>
 <productstore name="cfipython" type="arch" swap="true"/>
-<productstore name="static" type="arch" swap="true"/>
+<productstore name="static"    type="arch" swap="true"/>
 <productstore name="include"/>
 <productstore name="doc"/>
 <productstore name="python"/>

--- a/SCRAM/GMake/Makefile.cuda
+++ b/SCRAM/GMake/Makefile.cuda
@@ -38,8 +38,8 @@ endef
 define link_cuda_objs
   @$(startlog_$(1)) [ -d $(@D) ] ||  $(CMD_mkdir) -p $(@D) &&\
   $(CMD_echo) ">> Cuda Device Link $@ " &&\
-  $(VERB_ECHO) $(SCRAM_PREFIX_COMPILER_COMMAND) "$(NVCC) -dlink $(call AdjustFlags,$1,,CUDA_LDFLAGS CUDA_FLAGS) $(DLINK_LIBDIR) $(call Tool_DependencyDLINK,$1) --compiler-options '$(call AdjustCudaHostFlags,$1,CXXFLAGS) $(CXXSHAREDOBJECTFLAGS)' $2 -o $@" &&\
-              ($(SCRAM_PREFIX_COMPILER_COMMAND)  $(NVCC) -dlink $(call AdjustFlags,$1,,CUDA_LDFLAGS CUDA_FLAGS) $(DLINK_LIBDIR) $(call Tool_DependencyDLINK,$1) --compiler-options '$(call AdjustCudaHostFlags,$1,CXXFLAGS) $(CXXSHAREDOBJECTFLAGS)' $2 -o $@) $(endlog_$(1))
+  $(VERB_ECHO) $(SCRAM_PREFIX_COMPILER_COMMAND) "$(NVCC) -dlink $(DLINK_LIBDIR) $(call Tool_DependencyDLINK,$1) $(call AdjustFlags,$1,,CUDA_LDFLAGS CUDA_FLAGS) --compiler-options '$(call AdjustCudaHostFlags,$1,CXXFLAGS) $(CXXSHAREDOBJECTFLAGS)' $2 -o $@" &&\
+              ($(SCRAM_PREFIX_COMPILER_COMMAND)  $(NVCC) -dlink $(DLINK_LIBDIR) $(call Tool_DependencyDLINK,$1) $(call AdjustFlags,$1,,CUDA_LDFLAGS CUDA_FLAGS) --compiler-options '$(call AdjustCudaHostFlags,$1,CXXFLAGS) $(CXXSHAREDOBJECTFLAGS)' $2 -o $@) $(endlog_$(1))
 endef
 define generate_cuda_nv_objs
   @$(startlog_$(1)) [ -d $(@D) ] ||  $(CMD_mkdir) -p $(@D) &&\


### PR DESCRIPTION
Ensure that the dependent packages are linked before the CUDA "system" libraries, especially that libcudadevrt.a should go last.