### PR TITLE
Add -reflex to the rootcling invocation.

### DIFF
--- a/SCRAM/GMake/Makefile.rootdict
+++ b/SCRAM/GMake/Makefile.rootdict
@@ -10,8 +10,8 @@ endef
 define generate_rootdict
   @$(startlog_$(2))[ -d $(@D) ] ||  $(CMD_mkdir) -p $(@D) &&\
   $(CMD_echo) ">> Building Root dict from header file $< " &&\
-  $(VERB_ECHO) $(ROOTCLING) -f $@ $(call Tool_DependencyPCMS,$1) $(COMPILE_OPTIONS) -p -DGNU_SOURCE $(call AdjustFlags,$1,ROOTDICT,CPPFLAGS) $(patsubst $(SCRAM_SOURCEDIR)/%,%,$<) &&\
-  (            $(ROOTCLING) -f $@ $(call Tool_DependencyPCMS,$1) $(COMPILE_OPTIONS) -p -DGNU_SOURCE $(call AdjustFlags,$1,ROOTDICT,CPPFLAGS) $(patsubst $(SCRAM_SOURCEDIR)/%,%,$<) || ($(CMD_rm) -f $@ && exit 1)) &&\
+  $(VERB_ECHO) $(ROOTCLING) -reflex -f $@ $(call Tool_DependencyPCMS,$1) $(COMPILE_OPTIONS) -p -DGNU_SOURCE $(call AdjustFlags,$1,ROOTDICT,CPPFLAGS) $(patsubst $(SCRAM_SOURCEDIR)/%,%,$<) &&\
+  (            $(ROOTCLING) -reflex -f $@ $(call Tool_DependencyPCMS,$1) $(COMPILE_OPTIONS) -p -DGNU_SOURCE $(call AdjustFlags,$1,ROOTDICT,CPPFLAGS) $(patsubst $(SCRAM_SOURCEDIR)/%,%,$<) || ($(CMD_rm) -f $@ && exit 1)) &&\
   $(CMD_mv) $@ $@.base	&&\
   $(CMD_cat) $< $@.base > $@ &&\
   $(CMD_rm) -f $@.base $(endlog_$(2))


### PR DESCRIPTION
`rootcling -reflex` triggers the original genreflex behavior in rootcling.

This change after root-project/root#4547 should fix the issue in the
DataFormats/Provenance for the CXXMODULE IB.