### PR TITLE
Update ROCm static link rules

### DIFF
--- a/SCRAM/GMake/Makefile.rocm
+++ b/SCRAM/GMake/Makefile.rocm
@@ -35,6 +35,12 @@ $($(1)_objdir)/%.$(2).$(OBJEXT): $($(1)_srcdir)/%.$(2) $$($(1)_objdir)/precompil
 	$$(call compile_rocm,$(1),$(3))
 endef
 
+define generate_rocm_objs
+  @$(startlog_$(1)) [ -d $(@D) ] ||  $(CMD_mkdir) -p $(@D) &&\
+  $(CMD_echo) ">> Rocm Device Code Obj $@ " &&\
+  $(VERB_ECHO) $(SCRAM_PREFIX_COMPILER_COMMAND) "$(CMD_objcopy) -j '__CLANG_OFFLOAD_BUNDLE*' $^ $@" &&\
+              ($(SCRAM_PREFIX_COMPILER_COMMAND)  $(CMD_objcopy) -j '__CLANG_OFFLOAD_BUNDLE*' $^ $@) $(endlog_$(1))
+endef
 define generate_rocm_a
   @$(startlog_$(1)) [ -d $(@D) ] ||  $(CMD_mkdir) -p $(@D) && $(CMD_rm) -f $(SCRAMSTORENAME_STATIC)/$(@F) &&\
   $(CMD_echo) ">> Rocm Device Code library $@ " &&\
@@ -48,8 +54,11 @@ $(1)_EX_ROCM_DLINK_LIB := $(1)_rocm
 $(1)_libdeps+=$(WORKINGDIR)/cache/rocm_dlink/$(1)
 $(WORKINGDIR)/cache/rocm_dlink/$(1): $($(1)_objdir)/lib$(1)_rocm.$(AREXT) $$($(1)_rocm_dlink_deps)
 	@[ -d $$(@D) ] || $(CMD_mkdir) -p $$(@D) && $(CMD_touch) $$@
-$($(1)_objdir)/lib$(1)_rocm.$(AREXT): $($(1)_rocmobjs)
+$($(1)_objdir)/lib$(1)_rocm.$(AREXT): $(addprefix $($(1)_objdir)/, $(addsuffix _rocm.$(OBJEXT),$($(1)_rocmfiles)))
 	$$(call generate_rocm_a,$1) && $$(call copy_build_product,$(SCRAMSTORENAME_STATIC))
+$($(1)_objdir)/%_rocm.$(OBJEXT): $($(1)_objdir)/%.$(OBJEXT)
+	$$(call generate_rocm_objs,$1)
+
 all_$(1)+=$(PUB_DIRCACHE_MKDIR)/rocm_dlink/$(1).mk
 $(PUB_DIRCACHE_MKDIR)/rocm_dlink/$(1).mk: $(PUB_DIRCACHE_MKDIR)/rocm_dlink/scram.mk
 	@[ -d $$(@D) ] || $(CMD_mkdir) -p $$(@D) &&\


### PR DESCRIPTION
Update the ROCm build rules to bundle only the device-side libraries, with

    objcopy -j '__CLANG_OFFLOAD_BUNDLE*' file.hip.cc.o file.hip.cc.rocm_o`
    ...
    ar crs *.rocm_o archive_rocm.a