### PR TITLE
Fix the order of the ROCm flags

### DIFF
--- a/SCRAM/GMake/Makefile.rocm
+++ b/SCRAM/GMake/Makefile.rocm
@@ -25,7 +25,7 @@ $(eval $(call GenerateReleaseRocmDlink,$(FULL_RELEASE_FOR_A_PATCH),full))
 $(eval $(call GenerateReleaseRocmDlink,$(RELEASETOP),base))
 
 define compile_rocm_common
-  $(call run_compile_command,$2,$4,$5,$(HIPCC) -c $3 $(call AdjustRocmHostFlags,$1,CPPFLAGS CXXFLAGS) $(CXXSHAREDOBJECTFLAGS) $(if $(6),,$(CXX_MMD) $(CXX_MF) $(basename $@).d))
+  $(call run_compile_command,$2,$4,$5,$(HIPCC) -c $(call AdjustRocmHostFlags,$1,CPPFLAGS CXXFLAGS) $3 $(CXXSHAREDOBJECTFLAGS) $(if $(6),,$(CXX_MMD) $(CXX_MF) $(basename $@).d))
 endef
 define compile_rocm
   $(call compile_rocm_common,$1,$2,$(call AdjustFlags,$1,,ROCM_FLAGS))


### PR DESCRIPTION
Fix the order of the ROCm flags, to allow `ROCM_FLAGS` to override `CXXFLAGS`.