### PR TITLE
Enable Alpaka backends based on the architecture

### DIFF
--- a/Projects/CMSSW/Self.xml
+++ b/Projects/CMSSW/Self.xml
@@ -25,7 +25,13 @@
   <flags CHECK_PRIVATE_HEADERS="1"/>
   <flags SCRAM_TARGETS="haswell sandybridge nehalem"/>
   <flags OVERRIDABLE_FLAGS="CPPDEFINES CXXFLAGS FFLAGS CFLAGS CPPFLAGS LDFLAGS CUDA_FLAGS CUDA_LDFLAGS LTO_FLAGS ROCM_FLAGS ROCM_LDFLAGS"/>
-  <flags ALPAKA_BACKENDS="cuda rocm serial"/>
+  <flags ALPAKA_BACKENDS="serial"/>
+  <ifarchitecture name="!_gcc12">
+    <flags ALPAKA_BACKENDS="cuda"/>
+  </ifarchitecture>
+  <ifarchitecture name="_amd64_">
+    <flags ALPAKA_BACKENDS="rocm"/>
+  </ifarchitecture>
   <flags CODE_CHECK_ALPAKA_BACKEND="serial"/>
   <flags ENABLE_LTO="@ENABLE_LTO@"/>
  </client>


### PR DESCRIPTION
Enable the Alpaka backends for CUDA and ROCm only on the architectures that support them:
  - CUDA is enabled on all architectures, as long as gcc is < 12
  - ROCm is enabled only on x86