### PR TITLE
Rocm/Cuda unit test improvement

### DIFF
--- a/SCRAM/GMake/Makefile.alpaka
+++ b/SCRAM/GMake/Makefile.alpaka
@@ -8,3 +8,29 @@ $$(eval $$(call AddRocmRules,$1,$2))
 endif
 endif
 endef
+
+ifeq ($(strip $(UNITTESTING)),yes)
+$(foreach b,$(ALPAKA_SELECTED_BACKENDS),\
+  $(eval $(call ShellCMDs,alpakaIsEnabled$(ALPAKA_BACKEND_SUFFIX_$b)))\
+  $(eval AlpakaTest_$b:=\
+    $(if $(strip $(filter alpakaIsEnabled$(ALPAKA_BACKEND_SUFFIX_$b),$(CMD_alpakaIsEnabled$(ALPAKA_BACKEND_SUFFIX_$b)))),\
+      true,\
+      $(CMD_alpakaIsEnabled$(ALPAKA_BACKEND_SUFFIX_$b))))\
+  $(eval SKIP_ALPAKA_TESTS_$b:=$(shell $(AlpakaTest_$b) >/dev/null 2>&1 || $(CMD_echo) yes)))
+
+define AlpakaTestsFlag
+ifeq ($(strip $(filter alpaka-$2,$($(1)_LOC_USE))-$(SKIP_ALPAKA_TESTS_$2)),alpaka-$2-yes)
+$(1)_NO_TESTRUN := yes
+$(1)_TEST_SKIP_MSG:=Failed to run alpakaIsEnabled$(ALPAKA_BACKEND_SUFFIX_$2)
+else
+ifeq ($(strip $(filter $2,$($(1)_LOC_USE))-$(SKIP_ALPAKA_TESTS_$2)),$2-yes)
+$(1)_NO_TESTRUN := yes
+$(1)_TEST_SKIP_MSG:=Failed to run alpakaIsEnabled$(ALPAKA_BACKEND_SUFFIX_$2)
+endif
+endif
+endef
+
+define AlpakaTestsFlags
+$(foreach x,$(ALPAKA_SELECTED_BACKENDS),$(if $(strip $(UNITTEST_TYPES)),$(eval $(call UserTestsSelection,$1,$x)),$(eval $(call AlpakaTestsFlag,$1,$x))))
+endef
+endif

--- a/SCRAM/GMake/Makefile.rules
+++ b/SCRAM/GMake/Makefile.rules
@@ -64,6 +64,10 @@ COMMON_WORKINGDIR := $(SCRAM_TMP)/common
 WORKINGDIR := $(SCRAM_INTwork)
 UNITTEST_DIRNAME:=unit_tests
 UNITTEST_DIR := $(LOCALTOP)/$(UNITTEST_DIRNAME)
+UNITTEST_TYPES:=
+ifneq ($(strip $(USER_UNIT_TESTS)),)
+UNITTEST_TYPES:=$(strip $(USER_UNIT_TESTS) $(foreach b,$(ALPAKA_SELECTED_BACKENDS),$(if $(strip $(filter $b,$(USER_UNIT_TESTS))),alpaka-$b)))
+endif
 PRECOMPILE_FLAGS_EXTENSION  := cxxflags
 PRECOMPILE_EXTENSION        := gch
 YACC                        := bison
@@ -302,6 +306,13 @@ FFLAGS_COMPILER:=f77compiler
 GetCompilerType=$(if $(strip $1),$1,$(if $(strip $($2_COMPILER)),$($2_COMPILER),cxxcompiler))
 GetCompiler=$(if $(strip $2),$2,$(if $(strip $($1_LOC_FLAGS_COMPILER)),$($1_LOC_FLAGS_COMPILER),$(SCRAM_COMPILER)))
 GetVectorFlag=$(strip $(if $($1_LOC_FLAGS_COMPILER),$($($1_LOC_FLAGS_COMPILER)-cxxcompiler_EX_FLAGS_$3_TARGETS_$2),$($(SCRAM_COMPILER)-cxxcompiler_EX_FLAGS_$3_TARGETS_$2)))
+
+define UserTestsSelection
+ifeq ($(strip $(filter $(UNITTEST_TYPES),$($(1)_LOC_USE))),)
+$(1)_NO_TESTRUN := yes
+$(1)_TEST_SKIP_MSG:=Not a $(UNITTEST_TYPES) type test
+endif
+endef
 
 define SetCompilerTargetsFlag
   $(eval $(1)_SCRAM_TARGETS:=)
@@ -805,7 +816,7 @@ endef
 # Tesings test executable
 define run_test
   @if [ "X$($(1)_NO_TESTRUN)" == "Xyes" ] ; then \
-    $(CMD_printf) "Skip %5s ... $($(1)_PROD_PACKAGE)/$1\n" "0s"; \
+    $(CMD_printf) "Skip %5s ... $($(1)_PROD_PACKAGE)/$1 ($($(1)_TEST_SKIP_MSG))\n" "0s"; \
   else \
     $(if $(strip $(SCRAM_BUILDVERBOSE)),$(CMD_echo) "Package "$(patsubst $(SCRAM_SOURCEDIR)/%/test,%,$(4))": Running test $(1)" &&)\
     [ -d $($(1)_objdir) ] || $(CMD_mkdir) -p $($(1)_objdir) &&\
@@ -1124,6 +1135,8 @@ ifeq ($(strip $(4)),test)
 .PHONY: runtests_$(1) unittests_$(1)
 ifeq ($(strip $(filter $(1),$(SKIP_UNITTESTS))),$(1))
 $(1)_NO_TESTRUN := yes
+$(1)_TEST_SKIP_MSG:=Explicitly skipped via SKIP_UNITTESTS
+$(call AlpakaTestsFlags,$1)
 endif
 runtests_$(6) += unittests_$(1)
 unittests_$(6) += unittests_$(1)

--- a/SCRAM/Plugins/BuildRules.py
+++ b/SCRAM/Plugins/BuildRules.py
@@ -452,6 +452,10 @@ $(COMMON_WORKINGDIR)/cache/project_links: FORCE_TARGET
             sname = store['name'].upper().replace("/", "_")
             ref.write("SCRAMSTORENAME_%s:=%s\n" % (sname, storename))
             ref.write("ALL_PRODUCT_STORES+=$(SCRAMSTORENAME_%s)\n" % sname)
+        ref.write("ALPAKA_SELECTED_BACKENDS:=%s\n" % self.cache['SELECTED_ALPAKA_BACKENDS'])
+        for bend in self.cache['SELECTED_ALPAKA_BACKENDS'].split(' '):
+          if not bend: continue
+          ref.write("ALPAKA_BACKEND_SUFFIX_%s:=%s\n" % (bend,self.cache["SUPPORTED_ALPAKA_BACKENDS"][bend]))
         ref.close()
         return
 


### PR DESCRIPTION
Various unit tests improvements
- Unit tests with direct `rocm` or `alpaka` dependency (with `rocm` backend enabled)
  - Run tests if `alpakaIsEnabledROCmAsync` command is either missing or runs successfully
-  Unit tests with direct `cuda` or `alpaka` dependency (with `cuda` backend enabled)
   - Run tests if `alpakaIsEnabledCudaAsync` command is either missing or runs successfully

If `USER_UNIT_TESTS=<tools>` is set then `alpakaIsEnabledX` check is ignored and scram force runs unit tests which directory depend on `<tools>` e.g.  
- `USER_UNIT_TESTS=rocm scram build runtests` will run all tests which directly depend on `rocm` or `alpaka-rocm`. 
- `USER_UNIT_TESTS=cuda scram build runtests` will run all tests which directly depend on `cuda` or `alpaka-cuda`.
- `USER_UNIT_TESTS="cuda serial" scram build runtests` will run all tests which directly depend on `cuda` , `alpaka-cuda` or `aplaka-serial`.
- `USER_UNIT_TESTS="boost" scram build runtests` will run all tests which directly depend on `boost`