### PR TITLE
Copy all CFIPYTHON_PACKAGE_FILES files to cfipython store

### DIFF
--- a/SCRAM/GMake/Makefile.rules
+++ b/SCRAM/GMake/Makefile.rules
@@ -985,7 +985,12 @@ ifneq ($(UNITTESTING),yes)
 	@$(CMD_echo) ">> Leaving Package $(1)" &&\
 	$(CMD_echo) ">> Package $(1) built" $(if $(HOOK_PACKAGE), && $(HOOK_PACKAGE) -e -p $1 $(if $(KEEP_ON_BUILDING), || $(CMD_true)))
 endif
+ifneq ($(strip $(CFIPYTHON_PACKAGE_FILES)),)
+$$(foreach s,$$(CFIPYTHON_PACKAGE_FILES),$$(eval $$(call SetCfiPythonFileRules,$1,$$s)))
+$(SCRAMSTORENAME_CFIPYTHON)/$(1)/.scram: $(SCRAMSTORENAME_PYTHON)/$(1)/__init__.py | $(foreach s,$(CFIPYTHON_PACKAGE_FILES),$(SCRAMSTORENAME_CFIPYTHON)/$(1)/$(notdir $s))
+else
 $(SCRAMSTORENAME_CFIPYTHON)/$(1)/.scram: $(SCRAMSTORENAME_PYTHON)/$(1)/__init__.py
+endif
 	@[ -d $$(@D) ] || $(CMD_mkdir) -p $$(@D) && $(CMD_touch) $$@
 $(SCRAMSTORENAME_PYTHON)/$(1)/__init__.py: $(SCRAMSTORENAME_PYTHON)/$(dir $1)__init__.py
 	@[ -d $$(@D) ] || $(CMD_mkdir) -p $$(@D) &&\
@@ -1008,6 +1013,11 @@ scripts_$(2): all_$(2)_scripts
 runpython_$(2): $(SCRAMSTORENAME_PYTHON)/$(1)/__init__.py
 	@:
 endif
+endef
+
+define SetCfiPythonFileRules
+$(SCRAMSTORENAME_CFIPYTHON)/$(1)/$(notdir $2): $2
+	@[ -d $$(@D) ] || $(CMD_mkdir) -p $$(@D) && $(CMD_cp) $$< $$@
 endef
 
 define TargetPlugin
@@ -1793,6 +1803,9 @@ ROOTCLING:=LD_LIBRARY_PATH=$(ROOT_INTERFACE_BASE)/rootcling/lib:$$LD_LIBRARY_PAT
 endif
 ifneq ($(strip $(COND_SERIALIZATION)),)
 COND_SERIALIZATION_SCRIPT:=$(call find_project_file,$(COND_SERIALIZATION))
+endif
+ifneq ($(strip $(CFIPYTHON_PACKAGE_FILES)),)
+CFIPYTHON_PACKAGE_FILES:=$(strip $(foreach s,$(CFIPYTHON_PACKAGE_FILES),$(call find_project_file,$(s))))
 endif
 ##############################################################################
 self_EX_INCLUDE := $(subst $(LOCALTOP)/$(SCRAM_SOURCEDIR),$(LOCALTOP)/$(SCRAM_SOURCEDIR) $(LOCALTOP)/poison ,$(self_EX_INCLUDE))

--- a/SCRAM/Plugins/CMSSW/ExtraBuildRule.py
+++ b/SCRAM/Plugins/CMSSW/ExtraBuildRule.py
@@ -25,6 +25,7 @@ class ExtraBuildRule:
     def Project(self):
         common = self.buildrules
         fh = common.filehandle()
+        fh.write("CFIPYTHON_PACKAGE_FILES:=$(SCRAM_SOURCEDIR)/FWCore/ParameterSet/templates/modules.py\n")
         fh.write("COND_SERIALIZATION:=$(SCRAM_SOURCEDIR)/CondFormats/Serialization/python"
                  "/condformats_serialization_generate.py\n")
         fh.write("ALL_EXTRA_PRODUCT_RULES+=LCG\n")


### PR DESCRIPTION
This change allows to copy any file, set via CFIPYTHON_PACKAGE_FILES project configuration` in to cfipython store. This is needed by https://github.com/cms-sw/cmssw/pull/44396