### PR TITLE
Fix rocm compilation of dev.cc files

### DIFF
--- a/SCRAM/GMake/Makefile.rocm
+++ b/SCRAM/GMake/Makefile.rocm
@@ -70,7 +70,7 @@ endef
 define AddRocmRules
 $(1)_rocmfiles       := $(filter $(foreach e,$(ROCM_EXTRA_EXT),%.$e),$($(1)_files))
 $(1)_rocm_dlink_deps := $$(call rocm_dlink_deps,$1)
-ifeq ($(strip $($(1)_rocm)),1)
+ifneq ($$(strip $$($(1)_rocmfiles)),)
 $(1)_DISABLE_LTO     := 1
 $(1)_DISABLE_PGO     := 1
 $(1)_linker          := $(HIPCC)


### PR DESCRIPTION
Fixed the issue described in #105. I just changed an if statement to make it match the cuda logic.

https://github.com/cms-sw/cmssw-config/blob/95cbc7a0514813eb7797404d5f3ce1615ec40277/SCRAM/GMake/Makefile.cuda#L87

Closes #105, closes https://github.com/cms-sw/cmssw/issues/44506.