### PR TITLE
Set CLING_MODULES_CACHE_PATH

### DIFF
--- a/Projects/CMSSW/Self.xml
+++ b/Projects/CMSSW/Self.xml
@@ -51,6 +51,7 @@
  <runtime name="RIVET_ANALYSIS_PATH"   value="$LOCALTOP/external/$SCRAM_ARCH/lib/Rivet" type="path" handler="warn"/>
  <runtime name="LANG"                  value="C"/>
  <runtime name="TEST_SRTOPT_PATH"      value="$LOCALTOP/test/$SCRAM_ARCH"            type="path"/>
+ <runtime name="CLING_MODULES_CACHE_PATH"    value="$LOCALTOP/lib/$SCRAM_ARCH"       type="path"/>
  <ifrelease name="_CXXMODULE">
   <runtime name="CLING_PREBUILT_MODULE_PATH" value="$LOCALTOP/biglib/$SCRAM_ARCH"    type="path"/>
   <runtime name="CLING_PREBUILT_MODULE_PATH" value="$LOCALTOP/lib/$SCRAM_ARCH"       type="path"/>


### PR DESCRIPTION
Build ROOT pre-compiled modules (pcm files) in the CMSSW library directory.