### PR TITLE
Expose Make's jobserver to nvcc in the CUDA build rules

### DIFF
--- a/SCRAM/GMake/Makefile.cuda
+++ b/SCRAM/GMake/Makefile.cuda
@@ -35,7 +35,7 @@ define compile_cuda
 endef
 define CudaCompileRule
 $($(1)_objdir)/%.$(2).$(OBJEXT): $($(1)_srcdir)/%.$(2) $$($(1)_objdir)/precompile
-	$$(call compile_cuda,$(1),$(3))
+	+$$(call compile_cuda,$(1),$(3))
 endef
 
 define link_cuda_objs
@@ -77,7 +77,7 @@ $(WORKINGDIR)/cache/cuda_dlink/$(1): $($(1)_cuda_dlink_deps)
 endif
 $(1)_cudaobjs := $(addprefix $($(1)_objdir)/, $(addsuffix .$(OBJEXT),$($(1)_cudafiles)))
 $($(1)_cudadlink): $$($(1)_cudaobjs) $(WORKINGDIR)/cache/cuda_dlink/$(1)
-	$$(call link_cuda_objs,$1,$$($(1)_cudaobjs))
+	+$$(call link_cuda_objs,$1,$$($(1)_cudaobjs))
 endef
 
 #safename, plugin_type


### PR DESCRIPTION
**Prerequisite plumbing only, necessary for CUDA 13 `nvcc` `--jobserver` flag to work with Make 4.3** ([nvcc documentation](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#jobserver-jobserver))

Prefix the CUDA compile and device-link recipes with '+' so GNU Make treats them as recursive invocations and passes its jobserver down to `nvcc`. With Make < 4.4 (pipe-based jobserver) the jobserver file descriptors are only inherited by recipes Make considers recursive, so without this marking nvcc cannot reach the jobserver even when one exists.

Affects the two recipes that invoke `nvcc`: the per-extension compile rule (`nvcc -dc`) and the device-link rule (`nvcc -dlink`).

Note: recipes marked recursive are run under `-n`/`-t`/`-q` rather than only printed, and the jobserver is active only under `-jN` with N>1. Updating to Make >=4.4 should get rid of this plumbing requirement.